### PR TITLE
Added function for Remove punctuation characters from text .

### DIFF
--- a/PersianSwear.py
+++ b/PersianSwear.py
@@ -4,12 +4,23 @@ Author : Sorosh Safari @coci
 created date : 7 October, 2021
 updated date : 11 October, 2021
 """
+import json
+from string import punctuation
 class PersianSwear(object):
 	def __init__(self):
 		self.data = json.load(open('data.json'))
 
+	#Rmove punctuation characters from text
 	# return string
-	def filter_words(self, text, symbol="*"):
+	def ignoreSY(self, text):
+		for i in punctuation:
+				if i in text:
+					text=text.replace(i,'')
+		return text
+	# return string
+	def filter_words(self, ignoreOT, text , symbol="*"):
+		if ignoreOT:
+			text=self.ignoreSY(text)
 		if(self.is_empty()):
 			return text
 
@@ -35,12 +46,16 @@ class PersianSwear(object):
 		self.data['word'].remove(text)	
 
 	# return boolean
-	def is_bad(self, text):
+	def is_bad(self,ignoreOT, text):
+		if ignoreOT:
+			text=self.ignoreSY(text)
 		text=text.replace("\u200c","")
 		return text in self.data['word']
 
 	# return boolean
-	def has_swear(self, text):
+	def has_swear(self,ignoreOT, text):
+		if ignoreOT:
+			text=self.ignoreSY(text)
 		text=text.replace("\u200c","")
 		if(self.is_empty()):
 			return text

--- a/PersianSwear.py
+++ b/PersianSwear.py
@@ -19,14 +19,12 @@ class PersianSwear(object):
 		return text
 	# return string
 	def filter_words(self, ignoreOT, text , symbol="*"):
-		if ignoreOT:
-			text=self.ignoreSY(text)
 		if(self.is_empty()):
 			return text
 
 		text = text.split()
 		for i in range(len(text)):
-			if text[i] in self.data['word']:
+			if text[i] in self.data['word'] or (ignoreOT and self.ignoreSY(text[i]) in self.data['word']):
 				text[i] = symbol
 
 		return " ".join(text)

--- a/PersianSwear.py
+++ b/PersianSwear.py
@@ -18,7 +18,7 @@ class PersianSwear(object):
 					text=text.replace(i,'')
 		return text
 	# return string
-	def filter_words(self, ignoreOT, text , symbol="*"):
+	def filter_words(self, text , symbol="*" , ignoreOT=False):
 		if(self.is_empty()):
 			return text
 
@@ -44,14 +44,14 @@ class PersianSwear(object):
 		self.data['word'].remove(text)	
 
 	# return boolean
-	def is_bad(self,ignoreOT, text):
+	def is_bad(self, text , ignoreOT=False):
 		if ignoreOT:
 			text=self.ignoreSY(text)
 		text=text.replace("\u200c","")
 		return text in self.data['word']
 
 	# return boolean
-	def has_swear(self,ignoreOT, text):
+	def has_swear(self, text , ignoreOT=False):
 		if ignoreOT:
 			text=self.ignoreSY(text)
 		text=text.replace("\u200c","")

--- a/README.md
+++ b/README.md
@@ -115,24 +115,39 @@ echo $persianswear->tostring(); // show all swear words
 ```
 persianswear = PersianSwear()
 
-print(persianswear.is_bad('خر')) # True
+print(persianswear.is_bad(ignoreOT=False ,'خر')) # True
 
-print(persianswear.is_bad('امروز')) # False
+print(persianswear.is_bad(ignoreOT=False ,'امروز')) # False
 
-print(persianswear.is_bad('چرت و پرت')) # False
+print(persianswear.is_bad(ignoreOT=False ,'چرت و پرت')) # False
 
 persianswear.add_word('چرت و پرت')
-print(persianswear.is_bad('چرت و پرت')) # True
+print(persianswear.is_bad(ignoreOT=False ,'چرت و پرت')) # True
 
-print(persianswear.has_swear('تو دوست من هستی')) # False
+print(persianswear.has_swear(ignoreOT=False ,'تو دوست من هستی')) # False
 
-print(persianswear.has_swear('تو هیز هستی')) # True
+print(persianswear.has_swear(ignoreOT=False ,'تو هیز هستی')) # True
 
-print(persianswear.filter_words('تو دوست من هستی')) # تو دوست من هستی
+print(persianswear.filter_words(ignoreOT=False ,'تو دوست من هستی')) # تو دوست من هستی
 
-print(persianswear.filter_words('تو هیز هستی')) # تو * هستی
+print(persianswear.filter_words(ignoreOT=False ,'تو هیز هستی')) # تو * هستی
 
-print(persianswear.filter_words('تو هیز هستی', '&')) # تو & هستی
+print(persianswear.filter_words(ignoreOT=False ,'تو هیز هستی', '&')) # تو & هستی
+
+
+print(persianswear.is_bad(ignoreOT=True , 'خ.ر')) # True
+
+print(persianswear.is_bad(ignoreOT=True , 'ام.روز')) # False
+
+print(persianswear.has_swear(ignoreOT=True ,'تو دو.ست من هستی')) # False
+
+print(persianswear.has_swear(ignoreOT=False ,'تو اسک.ل هستی')) # True
+
+print(persianswear.filter_words(ignoreOT=True ,'تو دو.ست من هستی')) # تو دو.ست من هستی
+
+print(persianswear.filter_words(ignoreOT=False ,'تو هی.ز هستی')) # تو * هستی
+
+print(persianswear.filter_words(ignoreOT=False ,'تو هی.ز هس.تی')) # تو * هس.تی
 
 print(persianswear.tostring()) # show all swear words
 ```

--- a/README.md
+++ b/README.md
@@ -115,39 +115,39 @@ echo $persianswear->tostring(); // show all swear words
 ```
 persianswear = PersianSwear()
 
-print(persianswear.is_bad(ignoreOT=False ,'خر')) # True
+print(persianswear.is_bad(,'خر',ignoreOT=False )) # True
 
-print(persianswear.is_bad(ignoreOT=False ,'امروز')) # False
+print(persianswear.is_bad('امروز',ignoreOT=False )) # False
 
-print(persianswear.is_bad(ignoreOT=False ,'چرت و پرت')) # False
+print(persianswear.is_bad('چرت و پرت',ignoreOT=False )) # False
 
 persianswear.add_word('چرت و پرت')
-print(persianswear.is_bad(ignoreOT=False ,'چرت و پرت')) # True
+print(persianswear.is_bad('چرت و پرت' , ignoreOT=False )) # True
 
-print(persianswear.has_swear(ignoreOT=False ,'تو دوست من هستی')) # False
+print(persianswear.has_swear('تو دوست من هستی' , ignoreOT=False )) # False
 
-print(persianswear.has_swear(ignoreOT=False ,'تو هیز هستی')) # True
+print(persianswear.has_swear('تو هیز هستی' , ignoreOT=False )) # True
 
-print(persianswear.filter_words(ignoreOT=False ,'تو دوست من هستی')) # تو دوست من هستی
+print(persianswear.filter_words('تو دوست من هستی' , ignoreOT=False )) # تو دوست من هستی
 
-print(persianswear.filter_words(ignoreOT=False ,'تو هیز هستی')) # تو * هستی
+print(persianswear.filter_words('تو هیز هستی' , ignoreOT=False )) # تو * هستی
 
-print(persianswear.filter_words(ignoreOT=False ,'تو هیز هستی', '&')) # تو & هستی
+print(persianswear.filter_words('تو هیز هستی', '&' , ignoreOT=False )) # تو & هستی
 
 
-print(persianswear.is_bad(ignoreOT=True , 'خ.ر')) # True
+print(persianswear.is_bad('خ.ر' , ignoreOT=True )) # True
 
-print(persianswear.is_bad(ignoreOT=True , 'ام.روز')) # False
+print(persianswear.is_bad( 'ام.روز' , ignoreOT=True )) # False
 
-print(persianswear.has_swear(ignoreOT=True ,'تو دو.ست من هستی')) # False
+print(persianswear.has_swear('تو دو.ست من هستی' , ignoreOT=True )) # False
 
-print(persianswear.has_swear(ignoreOT=False ,'تو اسک.ل هستی')) # True
+print(persianswear.has_swear('تو اسک.ل هستی' , ignoreOT=True )) # True
 
-print(persianswear.filter_words(ignoreOT=True ,'تو دو.ست من هستی')) # تو دو.ست من هستی
+print(persianswear.filter_words('تو دو.ست من هستی',ignoreOT=True )) # تو دو.ست من هستی
 
-print(persianswear.filter_words(ignoreOT=False ,'تو هی.ز هستی')) # تو * هستی
+print(persianswear.filter_words('تو هی.ز هستی',ignoreOT=True )) # تو * هستی
 
-print(persianswear.filter_words(ignoreOT=False ,'تو هی.ز هس.تی')) # تو * هس.تی
+print(persianswear.filter_words('تو هی.ز هس.تی' , ignoreOT=True )) # تو * هس.تی
 
 print(persianswear.tostring()) # show all swear words
 ```


### PR DESCRIPTION
<p align="center">
  <img 
    width="150"
    height="150"
    src="https://github.com/AdolfMacro/AdolfMacro/blob/main/logo.png?raw=true"
  >
</p>
<br>
<br>
<br>
Hi, I added the ignoreSY function to the Python section, which removes punctuate characters from words to prevent bypassing filters.

for example :
```
print(persianswear.is_bad( 'خ.ر' , ignoreOT=True )) # True
print(persianswear.is_bad('اح.مق' , ignoreOT=True )) # True
```

> I added complete examples of it in Readme.md

